### PR TITLE
Remove 1em font-size from div.ws-menu-page code CSS style.

### DIFF
--- a/s2member/includes/menu-pages/menu-pages.css
+++ b/s2member/includes/menu-pages/menu-pages.css
@@ -114,7 +114,6 @@ div.ws-menu-page > h2:after
 }
 div.ws-menu-page code
 {
-	font-size   : 1em;
 	font-family : 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
 }
 div.ws-menu-page pre.code


### PR DESCRIPTION
See #30.
