### PR TITLE
Fixing Column Sorting for Integer Values

### DIFF
--- a/s2member/includes/classes/users-list.inc.php
+++ b/s2member/includes/classes/users-list.inc.php
@@ -288,19 +288,21 @@ if (!class_exists ("c_ws_plugin__s2member_users_list"))
 
 					switch($vars['orderby'])
 						{
+							// This isn't a usermeta value, so we don't need to `LEFT JOIN` here.
 							case 's2member_registration_time':
 								$query->query_orderby = "ORDER BY CAST(`user_registered` AS UNSIGNED) " . $vars['order'];
 							break;
 
+							// s2Member Subscription ID can contain non-integer characters. We don't `CAST` this value as `UNSIGNED`
 							case 's2member_subscr_id':
-								$query->query_from .= " LEFT JOIN `" . $wpdb->usermeta . "` `m` ON (" . $wpdb->users . ".ID = `m`.`user_id` AND `m`.`meta_key` = '" . esc_sql($wpdb->prefix . $vars['orderby']) . "')";
+								$query->query_from .= " LEFT JOIN `" . $wpdb->usermeta . "` `m` ON (`" . $wpdb->users . "`.`ID` = `m`.`user_id` AND `m`.`meta_key` = '" . esc_sql($wpdb->prefix . $vars['orderby']) . "')";
 								$query->query_orderby = "ORDER BY `m`.`meta_value` " . $vars['order'];
 							break;
 
 							case 's2member_auto_eot_time':
 							case 's2member_login_counter':
 							case 's2member_last_login_time':
-								$query->query_from .= " LEFT JOIN `" . $wpdb->usermeta . "` `m` ON (" . $wpdb->users . ".ID = `m`.`user_id` AND `m`.`meta_key` = '" . esc_sql($wpdb->prefix . $vars['orderby']) . "')";
+								$query->query_from .= " LEFT JOIN `" . $wpdb->usermeta . "` `m` ON (`" . $wpdb->users . "`.`ID` = `m`.`user_id` AND `m`.`meta_key` = '" . esc_sql($wpdb->prefix . $vars['orderby']) . "')";
 								$query->query_orderby = "ORDER BY CAST(`m`.`meta_value` AS UNSIGNED) " . $vars['order'];
 							break;
 						}


### PR DESCRIPTION
As detailed in #164

We don't cast the selection of the value (as that would change the value), but instead only `ORDER BY` the unsigned value.

@JasWSInc I brought the Subscription ID value out from this, as it's alphanumeric. Is that right?
