### PR TITLE
Bug fix. `registration_time()` to receive the `$user_id`. See: websharks...

### DIFF
--- a/s2member/includes/classes/access-cap-times.inc.php
+++ b/s2member/includes/classes/access-cap-times.inc.php
@@ -211,7 +211,7 @@ if(!class_exists('c_ws_plugin__s2member_access_cap_times'))
 
 				// $update_ac_times = empty($ac_times) ? FALSE : TRUE;
 				$ac_times_min = !empty($ac_times) ? min(array_keys($ac_times)) : 0;
-				if(($r_time = c_ws_plugin__s2member_registration_times::registration_time()) && (empty($ac_times_min) || $r_time < $ac_times_min))
+				if(($r_time = c_ws_plugin__s2member_registration_times::registration_time($user_id)) && (empty($ac_times_min) || $r_time < $ac_times_min))
 					$ac_times[number_format(($r_time += .0001), 4, '.', '')] = 'level0';
 
 				if(is_array($pr_times = get_user_option('s2member_paid_registration_times', $user_id)))

--- a/s2member/includes/classes/registration-times.inc.php
+++ b/s2member/includes/classes/registration-times.inc.php
@@ -65,7 +65,7 @@ if(!class_exists("c_ws_plugin__s2member_registration_times"))
 		 *
 		 * @return int A Unix timestamp, indicating Registration Time, else `0` on failure.
 		 */
-		public static function registration_time($user_id = FALSE)
+		public static function registration_time($user_id = 0)
 		{
 			foreach(array_keys(get_defined_vars()) as $__v) $__refs[$__v] =& $$__v;
 			do_action("ws_plugin__s2member_before_registration_time", get_defined_vars());


### PR DESCRIPTION
Please see: websharks/s2member#237
