### PR TITLE
WP v4 compat. `like_escape()` deprecated in favor of `wpdb::esc_like()`....

### DIFF
--- a/s2member/includes/classes/installation.inc.php
+++ b/s2member/includes/classes/installation.inc.php
@@ -213,11 +213,11 @@ if(!class_exists('c_ws_plugin__s2member_installation'))
 				if(is_multisite() && is_main_site() /* Site options? */)
 					delete_site_option('ws_plugin__s2member_options');
 
-				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(like_escape('s2member_'))."%'");
-				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(like_escape('_transient_s2m_'))."%'");
-				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(like_escape('_transient_timeout_s2m_'))."%'");
-				$wpdb->query("DELETE FROM `".$wpdb->postmeta."` WHERE `meta_key` LIKE '%".esc_sql(like_escape('s2member_'))."%'");
-				$wpdb->query("DELETE FROM `".$wpdb->usermeta."` WHERE `meta_key` LIKE '%".esc_sql(like_escape('s2member_'))."%'");
+				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('s2member_'))."%'");
+				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('_transient_s2m_'))."%'");
+				$wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('_transient_timeout_s2m_'))."%'");
+				$wpdb->query("DELETE FROM `".$wpdb->postmeta."` WHERE `meta_key` LIKE '%".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('s2member_'))."%'");
+				$wpdb->query("DELETE FROM `".$wpdb->usermeta."` WHERE `meta_key` LIKE '%".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('s2member_'))."%'");
 
 				do_action('ws_plugin__s2member_during_uninstall', get_defined_vars());
 			}

--- a/s2member/includes/classes/ip-restrictions.inc.php
+++ b/s2member/includes/classes/ip-restrictions.inc.php
@@ -204,8 +204,8 @@ if(!class_exists("c_ws_plugin__s2member_ip_restrictions"))
             $transient_entries = $prefix.md5("s2member_ip_restrictions_".(string)$restriction."_entries");
             $transient_security_breach = $prefix.md5("s2member_ip_restrictions_".(string)$restriction."_security_breach");
 
-            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(like_escape($transient_entries))."'");
-            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(like_escape($transient_security_breach))."'");
+            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape($transient_entries))."'");
+            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '%".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape($transient_security_breach))."'");
 
             do_action("ws_plugin__s2member_after_delete_reset_specific_ip_restrictions", get_defined_vars());
 
@@ -260,8 +260,8 @@ if(!class_exists("c_ws_plugin__s2member_ip_restrictions"))
 
             do_action("ws_plugin__s2member_before_delete_reset_all_ip_restrictions", get_defined_vars());
 
-            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(like_escape("_transient_s2m_ipr_"))."%'");
-            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(like_escape("_transient_timeout_s2m_ipr_"))."%'");
+            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape("_transient_s2m_ipr_"))."%'");
+            $wpdb->query("DELETE FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape("_transient_timeout_s2m_ipr_"))."%'");
 
             do_action("ws_plugin__s2member_after_delete_reset_all_ip_restrictions", get_defined_vars());
 

--- a/s2member/includes/classes/users-list.inc.php
+++ b/s2member/includes/classes/users-list.inc.php
@@ -81,7 +81,7 @@ if (!class_exists ("c_ws_plugin__s2member_users_list"))
 
 						if (is_admin() && !empty($GLOBALS['pagenow']) && $GLOBALS['pagenow'] === 'users.php')
 							if(isset ($query->query_vars) && !is_network_admin ()) // NOT in Network admin panels.
-								if (is_array($qv = $query->query_vars) && ($s = trim ($qv["search"], "* \t\n\r\0\x0B")) && ($s = "%" . esc_sql (like_escape ($s)) . "%"))
+								if (is_array($qv = $query->query_vars) && ($s = trim ($qv["search"], "* \t\n\r\0\x0B")) && ($s = "%" . esc_sql (c_ws_plugin__s2member_utils_strings::like_escape ($s)) . "%"))
 									{
 										$query->query_fields = "SQL_CALC_FOUND_ROWS DISTINCT(`" . $wpdb->users . "`.`ID`)";
 										$query->query_from = " FROM `" . $wpdb->users . "`, `" . $wpdb->usermeta . "`"; // Include meta table also.

--- a/s2member/includes/classes/utils-logs.inc.php
+++ b/s2member/includes/classes/utils-logs.inc.php
@@ -187,7 +187,7 @@ if(!class_exists('c_ws_plugin__s2member_utils_logs'))
 
 			if(!$stagger || is_float($stagger = time() / 2)) // Stagger this routine?
 			{
-				if(is_array($expired_s2m_transients = $wpdb->get_results("SELECT * FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(like_escape('_transient_timeout_s2m_'))."%' AND `option_value` < '".esc_sql(time())."' LIMIT 5")) && !empty($expired_s2m_transients))
+				if(is_array($expired_s2m_transients = $wpdb->get_results("SELECT * FROM `".$wpdb->options."` WHERE `option_name` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape('_transient_timeout_s2m_'))."%' AND `option_value` < '".esc_sql(time())."' LIMIT 5")) && !empty($expired_s2m_transients))
 				{
 					foreach($expired_s2m_transients as $expired_s2m_transient) // Delete the _timeout, and also the transient entry name itself.
 						if(($id = $expired_s2m_transient->option_id) && ($name = preg_replace('/_transient_timeout_/i', '_transient_', $expired_s2m_transient->option_name, 1)))

--- a/s2member/includes/classes/utils-strings.inc.php
+++ b/s2member/includes/classes/utils-strings.inc.php
@@ -559,6 +559,16 @@ if(!class_exists("c_ws_plugin__s2member_utils_strings"))
 							}
 						return str_replace(array("%2D", "%2E", "%5F", "%7E"), array("-", ".", "_", "~"), (string)$value);
 					}
+
+				public static function like_escape($string)
+				{
+					global $wpdb; // Global DB object reference.
+
+					if(method_exists($wpdb, 'esc_like'))
+						return $wpdb->esc_like($string);
+
+					return like_escape($string); // Deprecated in WP v4.0.
+				}
 			}
 	}
 ?>

--- a/s2member/includes/classes/utils-users.inc.php
+++ b/s2member/includes/classes/utils-users.inc.php
@@ -246,7 +246,7 @@ if(!class_exists('c_ws_plugin__s2member_utils_users'))
 			/** @var wpdb $wpdb */
 
 			if($user_login && $user_email) // Only if we have both of these.
-				if(($user_id = $wpdb->get_var("SELECT `ID` FROM `".$wpdb->users."` WHERE `user_login` LIKE '".esc_sql(like_escape($user_login))."' AND `user_email` LIKE '".esc_sql(like_escape($user_email))."' LIMIT 1")))
+				if(($user_id = $wpdb->get_var("SELECT `ID` FROM `".$wpdb->users."` WHERE `user_login` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape($user_login))."' AND `user_email` LIKE '".esc_sql(c_ws_plugin__s2member_utils_strings::like_escape($user_email))."' LIMIT 1")))
 					return $user_id; // Return the associated WordPress ID.
 
 			return FALSE; // Otherwise, return false.


### PR DESCRIPTION
... See: websharks/s2member#329
