### PR TITLE
Update s-badge.php for additional switch parms

### DIFF
--- a/s2member/includes/templates/badges/s-badge.php
+++ b/s2member/includes/templates/badges/s-badge.php
@@ -5,10 +5,12 @@ if(!defined('WPINC')) // MUST have WordPress.
 switch('%%v%%')
 {
 	case 'v2':
+	case '2':
 		$width_height_attr = 'width="180" height="58"';
 		$width_height_styles = 'width:180px; height:58px;';
 		break;
 	case 'v3':
+	case '3':
 		$width_height_attr = 'width="80" height="15"';
 		$width_height_styles = 'width:80px; height:15px;';
 		break;


### PR DESCRIPTION
The switch cases do not accurately reflect the parameter values sent via the shortcode generated (and example provided) of [s2Member-Security-Badge v="1" /] in the s2Member>>General Options>>s2Member Security Badge accordian for the 2nd and 3rd variations.

Notice this generated shortcode and example does not have v="v1", but rather it is implied that you should use v="2" or v="3".

This causes the badges generated via http://www.s2member.com/s-badges/s-details.php to be distorted when displayed because the width and height attributes are not correct (because default: is used to generate the HTML).