### PR TITLE
Bug fix in Stripe custom template support. See: websharks/s2member#510

### DIFF
--- a/s2member/includes/classes/paypal-notify-in-subscr-or-rp-eots-w-level.inc.php
+++ b/s2member/includes/classes/paypal-notify-in-subscr-or-rp-eots-w-level.inc.php
@@ -76,8 +76,8 @@ if(!class_exists('c_ws_plugin__s2member_paypal_notify_in_subscr_or_rp_eots_w_lev
 
 					if(empty($_REQUEST['s2member_paypal_proxy'])) // Only on true PayPal IPNs; e.g., we can bypass this on proxied IPNs.
 					{
-						$paypal['s2member_log'][] = 'Sleeping for 10 seconds. Waiting for a possible ( `subscr_signup|subscr_modify|recurring_payment_profile_created` ).';
-						sleep(10); // Sleep here for a moment. PayPal sometimes sends a subscr_eot before the subscr_signup, subscr_modify.
+						$paypal['s2member_log'][] = 'Sleeping for 15 seconds. Waiting for a possible ( `subscr_signup|subscr_modify|recurring_payment_profile_created` ).';
+						sleep(15); // Sleep here for a moment. PayPal sometimes sends a subscr_eot before the subscr_signup, subscr_modify.
 						$paypal['s2member_log'][] = 'Awake. It\'s '.date('D M j, Y g:i:s a T').'. s2Member `txn_type` identified as '.$identified_as.'.';
 					}
 					$paypal['ip'] = (preg_match('/ip address/i', $paypal['option_name2']) && $paypal['option_selection2']) ? $paypal['option_selection2'] : '';

--- a/s2member/includes/classes/paypal-notify-in-subscr-or-rp-payment-w-level.inc.php
+++ b/s2member/includes/classes/paypal-notify-in-subscr-or-rp-payment-w-level.inc.php
@@ -62,8 +62,8 @@ if(!class_exists('c_ws_plugin__s2member_paypal_notify_in_subscr_or_rp_payment_w_
 
 					if(empty($_REQUEST['s2member_paypal_proxy'])) // Only on true PayPal IPNs; e.g., we can bypass this on proxied IPNs.
 					{
-						$paypal['s2member_log'][] = 'Sleeping for 5 seconds. Waiting for a possible ( `subscr_signup|subscr_modify|recurring_payment_profile_created` ).';
-						sleep(5); // Sleep here for a moment. PayPal sometimes sends a subscr_payment before the subscr_signup, subscr_modify.
+						$paypal['s2member_log'][] = 'Sleeping for 15 seconds. Waiting for a possible ( `subscr_signup|subscr_modify|recurring_payment_profile_created` ).';
+						sleep(15); // Sleep here for a moment. PayPal sometimes sends a subscr_payment before the subscr_signup, subscr_modify.
 						$paypal['s2member_log'][] = 'Awake. It\'s '.date('D M j, Y g:i:s a T').'. s2Member `txn_type` identified as '.$identified_as.'.';
 					}
 					list($paypal['level'], $paypal['ccaps']) = preg_split('/\:/', $paypal['item_number'], 3);

--- a/s2member/includes/classes/paypal-notify-in.inc.php
+++ b/s2member/includes/classes/paypal-notify-in.inc.php
@@ -78,7 +78,7 @@ if(!class_exists('c_ws_plugin__s2member_paypal_notify_in'))
 
 					if(!empty($paypal['txn_type']) && $paypal['txn_type'] === 'merch_pmt')
 						// This is mostly irrelevant, but it helps to keep the logs cleaner.
-						sleep(5); // Wait for Pro-Form procesing to complete.
+						sleep(15); // Wait for Pro-Form procesing to complete.
 
 					if(empty($paypal['custom']) && !empty($paypal['recurring_payment_id'])) // Recurring Profile ID.
 						$paypal['custom'] = c_ws_plugin__s2member_utils_users::get_user_custom_with($paypal['recurring_payment_id']);


### PR DESCRIPTION
- Resolving issue with `%%source_token%%` in favor of `%%source_token_summary%%`.
- Resolving issue with `%%source_token_summary%%` check against file path instead of file contents.