### PR TITLE
Apply rounding after a timezone is set for [s2Eot /]; See: websharks/s2member#671

### DIFF
--- a/s2member/includes/classes/sc-eots-in.inc.php
+++ b/s2member/includes/classes/sc-eots-in.inc.php
@@ -92,9 +92,6 @@ if(!class_exists('c_ws_plugin__s2member_sc_eots_in'))
 				$eot = c_ws_plugin__s2member_utils_users::get_user_eot($user_id, true, $mode);
 				set_transient($transient, $eot, DAY_IN_SECONDS / 2);
 			}
-			if($eot['time'] && $attr['round_to'])
-				$eot['time'] = strtotime($attr['round_to'], $eot['time']);
-
 			if($eot['time'] && (integer)$attr['offset'])
 				$eot['time'] = $eot['time'] + (integer)$attr['offset'];
 
@@ -119,6 +116,8 @@ if(!class_exists('c_ws_plugin__s2member_sc_eots_in'))
 					$time = new DateTime(date('Y-m-d H:i:s', $eot['time']));
 					if($attr['timezone'] && strtoupper($attr['timezone']) !== 'UTC')
 						$time->setTimezone(new DateTimeZone($attr['timezone']));
+					if($attr['round_to'])
+						$time->modify($attr['round_to']);
 				}
 			if($time && $attr['date_format'] === 'timestamp')
 				$date = (string)$time->getTimestamp();


### PR DESCRIPTION
Apply rounding after a timezone is set for `[s2Eot /]`; 

![screen shot 2016-01-31 at 6 19 37 pm](https://cloud.githubusercontent.com/assets/7514953/12701585/28e8597a-c848-11e5-98cc-5ed533411346.png)

See: websharks/s2member#671